### PR TITLE
Postfix relay for allowed networks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 ansible_python_interpreter: python3
+
+# Allow STMP Relay for common private networks
+postfix_mynetworks:
+  - "10.0.0.0/8"
+  - "192.168.0.0/16"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,6 +129,7 @@
   with_items:
   - {'key': 'inet_interfaces', 'value': 'all'}
   - {'key': 'myhostname', 'value': 'straylight'}
+  - {'key': 'mynetworks', 'value': '{{ ( postfix_mynetworks + ["127.0.0.1/8"] ) | unique | join(", ") }}'}
   - {'key': 'header_checks', 'value': 'regexp:/etc/postfix/header_checks'}
   - {'file': 'header_checks', 'data': '/^Subject:/     WARN'}
   loop_control:


### PR DESCRIPTION
**New `postfix_mynetworks` variable**
It allows to specify postfix mynetworks configuration.
https://github.com/HackThisCompany/Wintermute-Straylight-ansible/blob/87c214d61e954000f01ebee04f10b8f2a7a23400/defaults/main.yml#L4-L7

Fixes #2 