### PR TITLE
Added --community flag to ntopng.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,6 +84,14 @@
   notify:
     - 'Restart ntopng'
 
+- name: Enable ntopng community edition
+  lineinfile:
+    path: /etc/ntopng/ntopng.conf
+    regex: "^--community"
+    line: --community
+  notify:
+    - 'Restart ntopng'
+
 - name: Uncompress html files
   unarchive:
     src: html.tar.gz


### PR DESCRIPTION
Default version breaks after a timeout due to license validities.
Useful references: https://github.com/HackThisCompany/Wintermute-Straylight-ansible/issues/5#issuecomment-645079295

Closes #5 .